### PR TITLE
Atualiza documentação da API

### DIFF
--- a/capitulos/equipamentos.md
+++ b/capitulos/equipamentos.md
@@ -5,6 +5,8 @@ Endpoints:
 
 - [Listar equipamentos](#listar-equipamentos)
 - [Obter equipamento específico](#obter-equipamento-específico)
+- [Listar meus equipamentos](#listar-meus-equipamentos)
+- [Listar equipamentos comunitários](#listar-equipamentos-comunitarios)
 
 Listar equipamentos
 --------------
@@ -187,4 +189,101 @@ curl -s https://olddragon.com.br/equipamentos/adaga.json
 
 ``` shell
 http https://olddragon.com.br/equipamentos/adaga.json
+```
+
+Listar meus equipamentos
+-------------------------
+
+* `GET /equipamentos/minhas.json` retorna todos os equipamentos personalizados do usuário autenticado.
+
+**Requer autenticação.**
+
+###### Exemplo de resposta JSON
+<!-- START equipment_my.json -->
+```json
+[
+  {
+    "id": "880e8400-e29b-41d4-a716-446655440000",
+    "type": "Equipment",
+    "name": "Equipamento Personalizado Um",
+    "concept": "misc",
+    "updated_at": "2023-01-01T00:00:00.000",
+    "access": "complete",
+    "cost": null,
+    "damage": null,
+    "bonus_ca": null,
+    "weight_in_load": null,
+    "weight_in_grams": null,
+    "description": "Este é um equipamento customizado criado por um jogador para testes.",
+    "fontes": [],
+    "author": {
+      "handler": "jogador",
+      "url": "https://olddragon.com.br/perfis/jogador.json"
+    },
+    "url": "https://olddragon.com.br/equipamentos/880e8400-e29b-41d4-a716-446655440000.json"
+  }
+]
+```
+<!-- END equipment_my.json -->
+
+###### Copiar como cURL
+
+``` shell
+curl -s https://olddragon.com.br/equipamentos/minhas.json -H "Authorization: Bearer <token>"
+```
+
+###### Copiar como HTTPie
+
+``` shell
+http https://olddragon.com.br/equipamentos/minhas.json Authorization:"Bearer <token>"
+```
+
+Listar equipamentos comunitários
+----------------------------------
+
+* `GET /equipamentos/comunitarias.json` retorna todos os equipamentos personalizados compartilhados pela comunidade (homebrew).
+
+_Parâmetros opcionais de URL_:
+
+* `name` - Filtro por nome. Exemplo: `name=Espada Longa Élfica`.
+* `order` - Ordenação (`name` ou `likes`). Padrão: `likes`.
+
+###### Exemplo de resposta JSON
+<!-- START equipment_homebrew.json -->
+```json
+[
+  {
+    "id": "880e8400-e29b-41d4-a716-446655440001",
+    "type": "Equipment",
+    "name": "Equipamento Personalizado Dois",
+    "concept": "misc",
+    "updated_at": "2023-01-01T00:00:00.000",
+    "access": "complete",
+    "cost": null,
+    "damage": null,
+    "bonus_ca": null,
+    "weight_in_load": null,
+    "weight_in_grams": null,
+    "description": "Este é outro equipamento customizado criado por um jogador para testes.",
+    "fontes": [],
+    "author": {
+      "handler": "outro_jogador",
+      "url": "https://olddragon.com.br/perfis/outro_jogador.json"
+    },
+    "url": "https://olddragon.com.br/equipamentos/880e8400-e29b-41d4-a716-446655440001.json"
+  }
+]
+```
+<!-- END equipment_homebrew.json -->
+
+###### Copiar como cURL
+
+``` shell
+curl -s https://olddragon.com.br/equipamentos/comunitarias.json
+```
+
+###### Copiar como HTTPie
+
+``` shell
+http https://olddragon.com.br/equipamentos/comunitarias.json
 ```

--- a/capitulos/magias.md
+++ b/capitulos/magias.md
@@ -5,6 +5,8 @@ Endpoints:
 
 - [Listar magias](#listar-magias)
 - [Obter magia específico](#obter-magia-específico)
+- [Listar minhas magias](#listar-minhas-magias)
+- [Listar magias comunitárias](#listar-magias-comunitarias)
 
 Listar magias
 -------------
@@ -226,6 +228,117 @@ curl -s https://olddragon.com.br/magias/luz.json
 
 ``` shell
 http https://olddragon.com.br/magias/luz.json
+```
+
+Listar minhas magias
+---------------------
+
+* `GET /magias/minhas.json` retorna todas as magias personalizadas do usuário autenticado.
+
+**Requer autenticação.**
+
+###### Exemplo de resposta JSON
+<!-- START spells_my.json -->
+```json
+[
+  {
+    "id": "770e8400-e29b-41d4-a716-446655440000",
+    "type": "Spell",
+    "name": "Magia Personalizada Um",
+    "arcane": 1,
+    "divine": null,
+    "necromancer": null,
+    "illusionist": null,
+    "updated_at": "2023-01-01T00:00:00.000",
+    "circles": {
+      "arcane": [
+        1
+      ]
+    },
+    "reverse": false,
+    "access": "complete",
+    "range": "",
+    "duration": "",
+    "jp": "",
+    "description": "Esta é uma magia customizada criada por um jogador para testes.",
+    "fontes": [],
+    "author": {
+      "handler": "jogador",
+      "url": "https://olddragon.com.br/perfis/jogador.json"
+    },
+    "url": "https://olddragon.com.br/magias/770e8400-e29b-41d4-a716-446655440000.json"
+  }
+]
+```
+<!-- END spells_my.json -->
+
+###### Copiar como cURL
+
+``` shell
+curl -s https://olddragon.com.br/magias/minhas.json -H "Authorization: Bearer <token>"
+```
+
+###### Copiar como HTTPie
+
+``` shell
+http https://olddragon.com.br/magias/minhas.json Authorization:"Bearer <token>"
+```
+
+Listar magias comunitárias
+----------------------------
+
+* `GET /magias/comunitarias.json` retorna todas as magias personalizadas compartilhadas pela comunidade (homebrew).
+
+_Parâmetros opcionais de URL_:
+
+* `name` - Filtro por nome. Exemplo: `name=Bola de Fogo`.
+* `order` - Ordenação (`name` ou `likes`). Padrão: `likes`.
+
+###### Exemplo de resposta JSON
+<!-- START spells_homebrew.json -->
+```json
+[
+  {
+    "id": "770e8400-e29b-41d4-a716-446655440001",
+    "type": "Spell",
+    "name": "Magia Personalizada Dois",
+    "arcane": 1,
+    "divine": null,
+    "necromancer": null,
+    "illusionist": null,
+    "updated_at": "2023-01-01T00:00:00.000",
+    "circles": {
+      "arcane": [
+        1
+      ]
+    },
+    "reverse": false,
+    "access": "complete",
+    "range": "",
+    "duration": "",
+    "jp": "",
+    "description": "Esta é outra magia customizada criada por um jogador para testes.",
+    "fontes": [],
+    "author": {
+      "handler": "outro_jogador",
+      "url": "https://olddragon.com.br/perfis/outro_jogador.json"
+    },
+    "url": "https://olddragon.com.br/magias/770e8400-e29b-41d4-a716-446655440001.json"
+  }
+]
+```
+<!-- END spells_homebrew.json -->
+
+###### Copiar como cURL
+
+``` shell
+curl -s https://olddragon.com.br/magias/comunitarias.json
+```
+
+###### Copiar como HTTPie
+
+``` shell
+http https://olddragon.com.br/magias/comunitarias.json
 ```
 
 ### Observações sobre atributos

--- a/capitulos/monstros.md
+++ b/capitulos/monstros.md
@@ -5,6 +5,8 @@ Endpoints:
 
 - [Listar monstros](#listar-monstros)
 - [Obter monstro específico](#obter-monstro-específico)
+- [Listar meus monstros](#listar-meus-monstros)
+- [Listar monstros comunitários](#listar-monstros-comunitarios)
 
 Listar monstros
 --------------
@@ -72,12 +74,12 @@ _Parâmetros opcionais de URL_:
     "dv": "1",
     "attacks": [
       {
-        "text": "1 × arma +3 (arma +0)",
+        "text": "1 × arma +3 (Arma)",
         "times": 1,
         "description": "arma",
         "ba": 3,
-        "damage_description": "arma +0",
-        "damage": "nil",
+        "damage_description": "Arma",
+        "damage": "",
         "damage_bonus": null,
         "weapon": true
       }
@@ -157,12 +159,12 @@ Obter monstro específico
   "dv": "1",
   "attacks": [
     {
-      "text": "1 × arma +3 (arma +0)",
+      "text": "1 × arma +3 (Arma)",
       "times": 1,
       "description": "arma",
       "ba": 3,
-      "damage_description": "arma +0",
-      "damage": "nil",
+      "damage_description": "Arma",
+      "damage": "",
       "damage_bonus": null,
       "weapon": true
     }
@@ -199,4 +201,139 @@ curl -s https://olddragon.com.br/monstros/orc.json
 
 ``` shell
 http https://olddragon.com.br/monstros/orc.json
+```
+
+Listar meus monstros
+-------------------------
+
+* `GET /monstros/minhas.json` retorna todos os monstros personalizados do usuário autenticado.
+
+**Requer autenticação.**
+
+###### Exemplo de resposta JSON
+<!-- START monsters_my.json -->
+```json
+[
+  {
+    "id": "880e8400-e29b-41d4-a716-446655440020",
+    "type": "Monster",
+    "name": "Monstro Personalizado Um",
+    "flavor": "",
+    "concept": "humanoide",
+    "size": "miudo",
+    "habitats": [],
+    "alignment": "ordeiro",
+    "variant": false,
+    "access": "complete",
+    "description": "\n\n\n\n",
+    "picture": null,
+    "thumb_picture": null,
+    "encounters": null,
+    "encounters_lair": null,
+    "xp": "",
+    "treasure": null,
+    "treasure_lair": null,
+    "mv": null,
+    "mvc": null,
+    "mve": null,
+    "mvn": null,
+    "mvv": null,
+    "mvo": null,
+    "dv_bonus": "",
+    "pv": "",
+    "ca": "",
+    "jp": "",
+    "mo": null,
+    "dv": "1",
+    "attacks": [],
+    "fontes": [],
+    "author": {
+      "handler": "jogador",
+      "url": "https://olddragon.com.br/perfis/jogador.json"
+    },
+    "url": "https://olddragon.com.br/monstros/880e8400-e29b-41d4-a716-446655440020.json"
+  }
+]
+```
+<!-- END monsters_my.json -->
+
+###### Copiar como cURL
+
+``` shell
+curl -s https://olddragon.com.br/monstros/minhas.json -H "Authorization: Bearer <token>"
+```
+
+###### Copiar como HTTPie
+
+``` shell
+http https://olddragon.com.br/monstros/minhas.json Authorization:"Bearer <token>"
+```
+
+Listar monstros comunitários
+----------------------------------
+
+* `GET /monstros/comunitarias.json` retorna todos os monstros personalizados compartilhados pela comunidade (homebrew).
+
+_Parâmetros opcionais de URL_:
+
+* `name` - Filtro por nome. Exemplo: `name=Monstro Personalizado Dois`.
+* `order` - Ordenação (`name` ou `likes`). Padrão: `likes`.
+
+###### Exemplo de resposta JSON
+<!-- START monsters_homebrew.json -->
+```json
+[
+  {
+    "id": "880e8400-e29b-41d4-a716-446655440021",
+    "type": "Monster",
+    "name": "Monstro Personalizado Dois",
+    "flavor": "",
+    "concept": "humanoide",
+    "size": "miudo",
+    "habitats": [],
+    "alignment": "ordeiro",
+    "variant": false,
+    "access": "complete",
+    "description": "\n\n\n\n",
+    "picture": null,
+    "thumb_picture": null,
+    "encounters": null,
+    "encounters_lair": null,
+    "xp": "",
+    "treasure": null,
+    "treasure_lair": null,
+    "mv": null,
+    "mvc": null,
+    "mve": null,
+    "mvn": null,
+    "mvv": null,
+    "mvo": null,
+    "dv_bonus": "",
+    "pv": "",
+    "ca": "",
+    "jp": "",
+    "mo": null,
+    "dv": "1",
+    "attacks": [],
+    "fontes": [],
+    "author": {
+      "handler": "outro_jogador",
+      "url": "https://olddragon.com.br/perfis/outro_jogador.json"
+    },
+    "url": "https://olddragon.com.br/monstros/880e8400-e29b-41d4-a716-446655440021.json"
+  }
+]
+```
+<!-- END monsters_homebrew.json -->
+
+###### Copiar como cURL
+
+``` shell
+curl -s https://olddragon.com.br/monstros/comunitarias.json
+```
+
+###### Copiar como HTTPie
+
+``` shell
+http https://olddragon.com.br/monstros/comunitarias.json
 ```

--- a/capitulos/perfis.md
+++ b/capitulos/perfis.md
@@ -11,13 +11,16 @@ Obter meu perfil
 
 **Autenticação obrigatória**: Este endpoint requer autenticação OAuth.
 
-* `GET /perfil.json` retorna o perfil do usuário autenticado, com contadores de recursos e links para suas coleções.
+* `GET /perfil.json` retorna a identidade pública do usuário autenticado (`display_name`, `bio` e `avatar_url` podem ser nulos), com contadores de recursos e links para suas coleções.
 
 ###### Exemplo de resposta JSON
 <!-- START profiles_show.json -->
 ```json
 {
   "handler": "jogador",
+  "display_name": null,
+  "bio": null,
+  "avatar_url": null,
   "url": "https://olddragon.com.br/perfis/jogador.json",
   "account": {
     "email": "jogador@olddragon.com.br"
@@ -29,6 +32,18 @@ Obter meu perfil
   "character_classes": {
     "count": 1,
     "url": "https://olddragon.com.br/classes/minhas.json"
+  },
+  "spells": {
+    "count": 1,
+    "url": "https://olddragon.com.br/magias/minhas.json"
+  },
+  "equipment": {
+    "count": 1,
+    "url": "https://olddragon.com.br/equipamentos/meus.json"
+  },
+  "monsters": {
+    "count": 1,
+    "url": "https://olddragon.com.br/monstros/meus.json"
   },
   "campaigns": {
     "count": 1,
@@ -61,13 +76,16 @@ http https://olddragon.com.br/perfil.json Authorization:"Bearer <token>"
 Obter perfil público
 ---------------------
 
-* `GET /perfis/:handler.json` retorna o perfil público de um usuário e suas raças e classes compartilhadas.
+* `GET /perfis/:handler.json` retorna a identidade pública de um usuário e suas criações compartilhadas.
 
 ###### Exemplo de resposta JSON
 <!-- START public_profiles_show.json -->
 ```json
 {
   "handler": "jogador",
+  "display_name": null,
+  "bio": null,
+  "avatar_url": null,
   "url": "https://olddragon.com.br/perfis/jogador.json",
   "character_races": [
     {
@@ -81,6 +99,27 @@ Obter perfil público
       "id": "660e8400-e29b-41d4-a716-446655440000",
       "name": "Classe Personalizada Um",
       "url": "https://olddragon.com.br/classes/660e8400-e29b-41d4-a716-446655440000.json"
+    }
+  ],
+  "spells": [
+    {
+      "id": "770e8400-e29b-41d4-a716-446655440000",
+      "name": "Magia Personalizada Um",
+      "url": "https://olddragon.com.br/magias/770e8400-e29b-41d4-a716-446655440000.json"
+    }
+  ],
+  "equipment": [
+    {
+      "id": "880e8400-e29b-41d4-a716-446655440000",
+      "name": "Equipamento Personalizado Um",
+      "url": "https://olddragon.com.br/equipamentos/880e8400-e29b-41d4-a716-446655440000.json"
+    }
+  ],
+  "monsters": [
+    {
+      "id": "880e8400-e29b-41d4-a716-446655440020",
+      "name": "Monstro Personalizado Um",
+      "url": "https://olddragon.com.br/monstros/880e8400-e29b-41d4-a716-446655440020.json"
     }
   ]
 }


### PR DESCRIPTION
Regenera os exemplos de resposta a partir dos testes de controller (`rails api:docs`).

Capítulos alterados:

- **equipamentos** — blocos de homebrew (`/equipamentos/minhas.json`, `/equipamentos/homebrew.json`) com bloco `author`
- **magias** — `circles`/`arcane` populados e blocos de homebrew
- **monstros** — blocos de homebrew com `author`
- **perfis** — URLs corrigidas para `meus.json` e contadores